### PR TITLE
make lesson suitable for teaching with locally-built (serverless) pages 

### DIFF
--- a/_extras/about.md
+++ b/_extras/about.md
@@ -1,6 +1,4 @@
 ---
-layout: page
 title: About
-permalink: /about/
 ---
 {% include carpentries.html %}

--- a/_extras/data.md
+++ b/_extras/data.md
@@ -1,10 +1,8 @@
 ---
-layout: page
-title: "Workshop data"
-permalink: /data/
+title: Workshop Data
 ---
 
-All of the ecology lessons use the same data set throughout. The data is tabular (rows and columns), similar in structure to what you might have in a spreadsheet. 
+All of the ecology lessons use the same data set throughout. The data is tabular (rows and columns), similar in structure to what you might have in a spreadsheet.
 
 ## The Portal Project Teaching Database
 
@@ -22,9 +20,9 @@ with it using exactly the same tools we'll learn about today.
 
 > ## Portal Project Teaching Dataset
 > The Portal Project Teaching Database is a simplified version of the Portal Project Database designed for teaching. It provides a real world example of life-history, population, and ecological data, with sufficient complexity to teach many aspects of data analysis and management, but with many complexities removed to allow students to focus on the core ideas and skills being taught.
-> 
+>
 > The database is currently available in csv, json, and sqlite.
-> 
+>
 > This database is not designed for research as it intentionally removes some of the real-world complexities. The original database is published at [Ecological Archives](http://esapubs.org/archive/ecol/E090/118/) and this version of the database should be used for research purposes. The Python code used for converting the original database to this teach version is included as 'create_portal_teach_dataset.py'. Suggested changes or additions to this dataset can be requested or contributed in the project GitHub repository [https://github.com/weecology/portal-teachingdb](https://github.com/weecology/portal-teachingdb).
 >
 > **CITATION:** Ernest, Morgan; Brown, James; Valone, Thomas; White, Ethan P. (2017): Portal Project Teaching Database. figshare. https://doi.org/10.6084/m9.figshare.1314459.v6
@@ -33,10 +31,10 @@ with it using exactly the same tools we'll learn about today.
 
 Files we use in this dataset:
 
-- [surveys.csv](https://ndownloader.figshare.com/files/2292172) - the survey data  
+- [surveys.csv](https://ndownloader.figshare.com/files/2292172) - the survey data
 Fields: record_id, month, day, year, plot_id, species_id, sex, hindfoot_length, weight
-- [plots.csv](https://ndownloader.figshare.com/files/3299474) - information on plot number and type  
+- [plots.csv](https://ndownloader.figshare.com/files/3299474) - information on plot number and type
 Fields: plot_id, plot_type
-- [species.csv](https://ndownloader.figshare.com/files/3299483) - information on species codes and scientific name  
+- [species.csv](https://ndownloader.figshare.com/files/3299483) - information on species codes and scientific name
 Fields: species_id, genus, species, taxa
 - [portal_mammals.sqlite](https://ndownloader.figshare.com/files/2292171) - database of survey, plots and species tables

--- a/_extras/discuss.md
+++ b/_extras/discuss.md
@@ -1,6 +1,4 @@
 ---
-layout: page
 title: Discussion
-permalink: /discuss/
 ---
 FIXME

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -1,6 +1,4 @@
 ---
-layout: page
-title: "Instructor Notes"
-permalink: /guide/
+title: Instructor Notes
 ---
 FIXME

--- a/_includes/setup-data.md
+++ b/_includes/setup-data.md
@@ -5,6 +5,6 @@ You can download all of the data used in this workshop by clicking
 
 Clicking the download link will automatically download all of the files to your default download directory as a single compressed
 (`.zip`) file. To expand this file, double click the folder icon in your file navigator application (for Macs, this is the Finder
-application). 
+application).
 
-For a full description of the data used in this workshop see the [data page](data).
+For a full description of the data used in this workshop see the [data page]({{ relative_root_path}}{% link _extras/data.md %}).

--- a/index.md
+++ b/index.md
@@ -1,44 +1,45 @@
 ---
 layout: lesson
 root: .
+permalink: index.html
 ---
 
-Data Carpentry's aim is to teach researchers basic concepts, skills, and tools for working with data so that they can get more done in less time, and with less pain. This workshop uses a tabular ecology dataset and teaches data cleaning, management, analysis and visualization. 
+Data Carpentry's aim is to teach researchers basic concepts, skills, and tools for working with data so that they can get more done in less time, and with less pain. This workshop uses a tabular ecology dataset and teaches data cleaning, management, analysis and visualization.
 
 
 > ## Getting Started
 >
-> Data Carpentry’s teaching is hands-on, so participants are encouraged to use 
-> their own computers to ensure the proper setup of tools for an efficient 
-> workflow. To most effectively use these materials, please make sure to download 
-> the data and install everything before working through this lesson. 
-> 
+> Data Carpentry’s teaching is hands-on, so participants are encouraged to use
+> their own computers to ensure the proper setup of tools for an efficient
+> workflow. To most effectively use these materials, please make sure to download
+> the data and install everything before working through this lesson.
+>
 > This workshop assumes no prior experience with the tools covered in the workshop.
 >
-> To get started, follow the directions in the [Setup](setup.html) tab to
+> To get started, follow the directions in the [Setup](.{% link setup.md %}) tab to
 > get access to the required software and data for this workshop.
 {: .prereq}
 
 > ## Data
-> 
+>
 > The data for this workshop are is the [Portal Project Teaching Database](https://figshare.com/articles/Portal_Project_Teaching_Database/1314459) available on FigShare, with a CC-BY license available for reuse.
 >
-> The Portal Project Teaching Database is a simplified version of the Portal 
+> The Portal Project Teaching Database is a simplified version of the Portal
 > Project Database designed for teaching. It is a tabular dataset of observations
 > of small mammals in a desert ecosystem in Arizona, USA, collected over more than 40 years.
-> It provides a real world example of 
-> life-history, population, and ecological data, with sufficient complexity to 
+> It provides a real world example of
+> life-history, population, and ecological data, with sufficient complexity to
 > teach many aspects of data analysis and management, but with many complexities
 > removed to allow students to focus on the core ideas and skills being taught.
 >
-> [More information on this dataset](data)
+> [More information on this dataset](.{% link _extras/data.md %})
 {: .prereq}
 
 # Workshop Overview
 
-The workshop can be taught using R or Python as the base language. All workshops start with a lesson on organizing data effectively in 
-spreadsheets, followed by a lesson on data cleaning with OpenRefine. Each workshop will then include **either** a lesson on R **or** a 
-lesson on Python. Both the R and Python lessons focus on data import, exploratory data analysis, and visualization. Workshops may also 
+The workshop can be taught using R or Python as the base language. All workshops start with a lesson on organizing data effectively in
+spreadsheets, followed by a lesson on data cleaning with OpenRefine. Each workshop will then include **either** a lesson on R **or** a
+lesson on Python. Both the R and Python lessons focus on data import, exploratory data analysis, and visualization. Workshops may also
 include a lesson on working with data in a relational database using SQL, at the discretion of the instructors.
 
 | Lesson    | Overview |
@@ -48,5 +49,3 @@ include a lesson on working with data in a relational database using SQL, at the
 | [Data Analysis and Visualization in R for Ecologists](https://datacarpentry.org/R-ecology-lesson/) | Import data into R, calculate summary statistics, and create publication-quality graphics. |
 | [Data Analysis and Visualization with Python for Ecologists](https://datacarpentry.org/python-ecology-lesson/) | Import data into Python, calculate summary statistics, and create publication-quality graphics. |
 | [Data Management with SQL for Ecologists	](https://datacarpentry.org/sql-ecology-lesson/) | Structure data for database import. Query data within a relational database. |
-
-

--- a/reference.md
+++ b/reference.md
@@ -1,6 +1,5 @@
 ---
 layout: reference
-permalink: /reference/
 ---
 
 ## Glossary

--- a/setup-python-workshop.md
+++ b/setup-python-workshop.md
@@ -1,10 +1,9 @@
 ---
-layout: page
-title: Setup for Python workshop
+title: Setup for Python workshops
 ---
 
+{% include base_path.html %}
 {% include setup-overview.md %}
-
 {% include setup-data.md %}
 
 ## Software
@@ -12,9 +11,9 @@ title: Setup for Python workshop
 | Software | Install | Manual | Available for | Description |
 | -------- | ------------ | ------ | ------------- | ----------- |
 | Spreadsheet program | [Link](https://www.libreoffice.org/download/download/) | [Link](https://documentation.libreoffice.org/en/english-documentation/) | Linux, MacOS, Windows | Spreadsheet program for organizing tabular data. |
-| OpenRefine |[Link](http://openrefine.org/download.html) | [Link](http://openrefine.org/documentation.html) | Linux, MacOS, Windows | Program for reproducibly cleaning data. | 
+| OpenRefine |[Link](http://openrefine.org/download.html) | [Link](http://openrefine.org/documentation.html) | Linux, MacOS, Windows | Program for reproducibly cleaning data. |
 | Python | See install instructions below. |  | Linux, MacOS, Windows | Programming language for data analysis and visualisation. |
-| SQLite Browser | [Link](http://sqlitebrowser.org/dl/) | [Link](https://github.com/sqlitebrowser/sqlitebrowser/wiki) | Linux, MacOS, Windows | Tool for creating, designing, and editing database files. | 
+| SQLite Browser | [Link](http://sqlitebrowser.org/dl/) | [Link](https://github.com/sqlitebrowser/sqlitebrowser/wiki) | Linux, MacOS, Windows | Tool for creating, designing, and editing database files. |
 
 
 {% include setup-spreadsheet.md %}
@@ -22,7 +21,7 @@ title: Setup for Python workshop
 {% include setup-openrefine.md %}
 
 {% include setup-python.md %}
-  
+
 {% include setup-sql.md %}
 
 Congratulations! You are now ready for the workshop!

--- a/setup-r-workshop.md
+++ b/setup-r-workshop.md
@@ -1,8 +1,8 @@
 ---
-layout: page
 title: Setup for R workshops
 ---
 
+{% include base_path.html %}
 {% include setup-overview.md %}
 {% include setup-data.md %}
 
@@ -12,10 +12,10 @@ title: Setup for R workshops
 | Software | Install | Manual | Available for | Description |
 | -------- | ------------ | ------ | ------------- | ----------- |
 | Spreadsheet program | [Link](https://www.libreoffice.org/download/download/) | [Link](https://documentation.libreoffice.org/en/english-documentation/) | Linux, MacOS, Windows | Spreadsheet program for organizing tabular data. |
-| OpenRefine |[Link](http://openrefine.org/download.html) | [Link](http://openrefine.org/documentation.html) | Linux, MacOS, Windows | Program for reproducibly cleaning data. |  
+| OpenRefine |[Link](http://openrefine.org/download.html) | [Link](http://openrefine.org/documentation.html) | Linux, MacOS, Windows | Program for reproducibly cleaning data. |
 | R | See install instructions below. | | Linux, MacOS, Windows | Programming language for data analysis and visualisation. |
 | RStudio | [Link](https://www.rstudio.com/products/rstudio/download/#download) | [Cheatsheet](https://github.com/rstudio/cheatsheets/raw/master/rstudio-ide.pdf) | Linux, MacOS, Windows| Integrated development environment for R. |
-| SQLite Browser | [Link](http://sqlitebrowser.org/dl/) | [Link](https://github.com/sqlitebrowser/sqlitebrowser/wiki) | Linux, MacOS, Windows | Tool for creating, designing, and editing database files. | 
+| SQLite Browser | [Link](http://sqlitebrowser.org/dl/) | [Link](https://github.com/sqlitebrowser/sqlitebrowser/wiki) | Linux, MacOS, Windows | Tool for creating, designing, and editing database files. |
 
 
 {% include setup-spreadsheet.md %}
@@ -23,7 +23,7 @@ title: Setup for R workshops
 {% include setup-openrefine.md %}
 
 {% include setup-r.md %}
-  
+
 {% include setup-sql.md %}
 
 Congratulations! You are now ready for the workshop!

--- a/setup.md
+++ b/setup.md
@@ -1,15 +1,15 @@
 ---
-layout: page
 title: Setup
 ---
 
+{% include base_path.html %}
 {% include setup-overview.md %}
 
 
 ## Setup instructions for your workshop
 
 * If you are attending a workshop where Python will be taught,
-  follow [these setup instructions]({{ site.baseurl }}{% link setup-python-workshop.md %})
-  
+  follow [these setup instructions]({{ relative_root_path }}{% link setup-python-workshop.md %})
+
 * If you are attending a workshop where R will be taught,
-  follow [these setup instructions]({{site.baseurl }}{% link setup-r-workshop.md %})
+  follow [these setup instructions]({{ relative_root_path }}{% link setup-r-workshop.md %})


### PR DESCRIPTION
See discussion here for more background: https://github.com/datacarpentry/datacarpentry.github.io/issues/542

In short, some Carpentries lessons use the path `/guide/` for their Instructor Notes page and others use `/guide/index.html` (the default defined in `_config.yml`). This PR removes permalinks with a trailing slash from the YAML front matter of the Instructor Notes (`_extras/guide.md`) and other Extras files, consistent with new lessons created with [the lesson template](https://github.com/carpentries/styles/). Although there's no functional difference in the online versions of the lesson pages, pages with a trailing slash in the permalink will result in **broken links in the version of the lesson built locally**. Additionally, this lesson has various internal links and inclusions to provide setup instructions and information about the data set, which were often broken in the locally-built site. We'd like local builds to be usable e.g. in workshops taking place at locations with limited or unreliable Internet access. 

Keeping the paths to these files consistent will also help us avoid broken links on the [Data Carpentry Lessons page](https://datacarpentry.org/lessons/), and ensure that equivalent paths in new lessons created with the template are consistent with previously-developed lessons like this one.

I did a sweep through the lesson and adjusted internal links as part of this PR. If and when this is merged, I'll also make sure the link on https://datacarpentry.org/lessons/ to the Instructor Notes page isn't broken, and make another sweep through the lesson pages too. 

Finally, I also removed the `layout` field from several pages, as the default layout is already set for Episodes and Extras pages in `_config.yml`.