### PR TITLE
Update index page to remove redirected www links

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Overview of the lessons:
   * Data analysis and visualization in R or Python
   * SQL for data management
 
-An example of the ecology materials in the wild is this [Data Carpentry workshop at CalTech](http://www.datacarpentry.org/2015-11-23-caltech/) in 2015.
+An example of the ecology materials in the wild is this [Data Carpentry workshop at CalTech](http://datacarpentry.org/2015-11-23-caltech/) in 2015.
 
 ## Detailed structure
 
@@ -23,19 +23,19 @@ An example of the ecology materials in the wild is this [Data Carpentry workshop
 
 There are two lessons in this section. The first is a spreadsheet lesson that teaches  good data organization, and some data cleaning and quality control checking in a spreadsheet program.
 
-  * [spreadsheet lesson](http://www.datacarpentry.org/spreadsheet-ecology-lesson/)
+  * [spreadsheet lesson](http://datacarpentry.org/spreadsheet-ecology-lesson/)
   * [spreadsheet repository](https://github.com/datacarpentry/spreadsheet-ecology-lesson)
 
 The second lesson uses a spreadsheet-like program called [OpenRefine](http://openrefine.org/) to teach data cleaning and filtering, and to introduce scripting, regular expressions and APIs (application programming interfaces).
 
-  * [OpenRefine lesson](http://www.datacarpentry.org/OpenRefine-ecology-lesson/)
+  * [OpenRefine lesson](http://datacarpentry.org/OpenRefine-ecology-lesson/)
   * [OpenRefine repository](https://github.com/datacarpentry/OpenRefine-ecology-lesson)
 
 ### Day 1 afternoon and Day 2 morning: Data analysis & visualization
 
 These lessons includes a basic introduction to R or Python syntax, importing CSV data, and subsetting and merging data. It finishes with calculating summary statistics and creating simple plots.
 
-  * [R lesson](http://www.datacarpentry.org/R-ecology-lesson/) and [Python lesson](http://www.datacarpentry.org/python-ecology-lesson/)
+  * [R lesson](http://datacarpentry.org/R-ecology-lesson/) and [Python lesson](http://datacarpentry.org/python-ecology-lesson/)
   * [R repository](https://github.com/datacarpentry/R-ecology-lesson) and [Python repository](https://github.com/datacarpentry/python-ecology-lesson)
 
 
@@ -43,7 +43,7 @@ These lessons includes a basic introduction to R or Python syntax, importing CSV
 
 This lesson introduces the concept of a database using SQLite, how to structure data for easy database import, and how to import tabular data into SQLite. Then, it teaches basic queries, combining results and doing queries across multiple tables.  
 
-  * [SQL lesson](http://www.datacarpentry.org/sql-ecology-lesson/)
+  * [SQL lesson](http://datacarpentry.org/sql-ecology-lesson/)
   * [SQL repository](https://github.com/datacarpentry/sql-ecology-lesson)
 
 ## Other lessons

--- a/index.md
+++ b/index.md
@@ -44,8 +44,8 @@ include a lesson on working with data in a relational database using SQL, at the
 
 | Lesson    | Overview |
 | ------- | ---------- |
-| [Data Organization in Spreadsheets for Ecologists](http://www.datacarpentry.org/spreadsheet-ecology-lesson/) | Learn how to organize tabular data, handle date formatting, carry out quality control and quality assurance and export data to use with downstream applications. |
-| [Data Cleaning with OpenRefine for Ecologists	](http://www.datacarpentry.org/OpenRefine-ecology-lesson/) | Explore, summarize, and clean tabular data reproducibly. |
+| [Data Organization in Spreadsheets for Ecologists](http://datacarpentry.org/spreadsheet-ecology-lesson/) | Learn how to organize tabular data, handle date formatting, carry out quality control and quality assurance and export data to use with downstream applications. |
+| [Data Cleaning with OpenRefine for Ecologists	](http://datacarpentry.org/OpenRefine-ecology-lesson/) | Explore, summarize, and clean tabular data reproducibly. |
 | [Data Analysis and Visualization in R for Ecologists](https://datacarpentry.org/R-ecology-lesson/) | Import data into R, calculate summary statistics, and create publication-quality graphics. |
 | [Data Analysis and Visualization with Python for Ecologists](https://datacarpentry.org/python-ecology-lesson/) | Import data into Python, calculate summary statistics, and create publication-quality graphics. |
 | [Data Management with SQL for Ecologists	](https://datacarpentry.org/sql-ecology-lesson/) | Structure data for database import. Query data within a relational database. |


### PR DESCRIPTION
A few links from the Workshop Overview section still point to
www.datacarpentry.org. The domain being used now doesn't
include the www. This updates the old links in the page to match
this usage.

This doesn't cause any issues with the website, but it
is causing us some issues in a project we're working on to
help facilitation computational training where internet access
is limited.