### PR TITLE
Update OpenRefine install instructions

### DIFF
--- a/_includes/setup-openrefine.md
+++ b/_includes/setup-openrefine.md
@@ -2,13 +2,12 @@
 
 * OpenRefine is a Java program that runs on your local machine (not on the cloud). Although it displays in your browser, no web 
 connection is needed and your data remains local. You need to have a ‘Java Runtime Environment’ (JRE) installed on your computer to run 
-OpenRefine. If you don’t already have one installed then you can download and install from http://java.com by going to the site and 
-clicking “Free Java Download”.
+OpenRefine. If you don’t already have one installed and are running Windows, then you can download the "Windows kit with embedded Java" version from the downloads page. You can also download and install Java from https://java.com by going to the site and clicking “Free Java Download”.
 
-* To install OpenRefine, go to their [download page](http://openrefine.org/download.html). From the download page, select either "Windows 
+* To install OpenRefine, go to their [download page](https://openrefine.org/download.html). From the download page, select either "Windows 
 kit", "Mac kit", or "Linux kit" - depending on your operating system - and follow the instructions next to your download link. This 
-lesson has been tested with all versions of OpenRefine up to the latest tested version, 3.2. **If you are using an older version, it is 
-recommended you upgrade to the latest tested version.** After installing, you can delete the installer `.dmg` file. 
+lesson has been tested with the recent versions of OpenRefine, at least 3.4.1. **If you are using an older version, it is 
+recommended you upgrade to the latest tested version.** 
 
 * You may get an error message: "OpenRefine.app can't be opened because it is from an unidentified developer." If you get this message, 
 open your system preferences and click "Security & Privacy". You will see a message "OpenRefine.app was blocked from opening because it


### PR DESCRIPTION
* Updated the version of OpenRefine for which the lesson was tested (3.4.1). 
* Added mention of version with embedded Java. 
* Changed links to https.