### PR TITLE
Update setup instructions for Python

### DIFF
--- a/files/setup-python.md
+++ b/files/setup-python.md
@@ -4,67 +4,53 @@
 
 ### Python and Jupyter Notebooks
 
-- [Python](https://python.org) is a popular language for
-  scientific computing, and great for general-purpose programming as
-  well. For this workshop we use Python version 3.x.
-  Installing all of its scientific packages individually can be
-  a bit difficult, so we recommend an all-in-one installer.
-  We will use Anaconda or Miniconda.
-  They both use [Conda](https://conda.io/en/latest/). The main difference is
-  that Anaconda comes with a lot of packages pre-installed.
-  With Miniconda you will need to install the required packages.
-  We recommend using the Anaconda installation instructions.
+[Python](https://python.org) is a popular language for scientific computing, and great for general-purpose programming as well. 
+For this workshop we use Python version 3.x.
+Installing all of its scientific packages individually can be a bit difficult, so we provide an environment file to help you take care of them all together.
+We will use the _Miniforge_ distribution of Python.
 
-:::::::::::::::: spoiler
+Please refer to the [Python section of the workshop website for installation instructions](https://carpentries.github.io/workshop-template/install_instructions/#python).
 
-## Anaconda installation
+#### Launching Jupyter
 
-Download and install [Anaconda](https://www.anaconda.com/download).
-Remember to choose the installer for Python 3.x.
-Anaconda does not include the plotting package plotnine.  To install this package, open your terminal application and
-type:
+:::::::::::::::::::::::::::::::::::::::::: spoiler
 
-```bash
-conda install -c conda-forge plotnine
-```
+##### Windows
 
-:::::::::::::::::::::::::
+After following the instructions above, search for the application 'Miniforge Prompt' and open it. 
+Type the following commands, pressing <kbd>Enter</kbd> after each one:
 
-:::::::::::::::: spoiler
+1. `conda activate carpentries`
+2. `jupyter notebook`
 
-## Miniconda installation
+::::::::::::::::::::::::::::::::::::::::::::::::::
 
-Miniconda is a "light" version of Anaconda. If you install and use Miniconda
-you will also need to install the workshop packages.
+:::::::::::::::::::::::::::::::::::::::::: spoiler
 
-Download and install [Miniconda](https://docs.conda.io/en/latest/miniconda.html)
-following the instructions. Remember to choose the installer for
-Python 3.x.
+##### MacOS
 
-From your terminal application, type:
+After following the instructions above, open the Terminal application (inside Applications/Utilities). 
+Type the following commands, pressing <kbd>Enter</kbd> after each one:
 
-```bash
-conda list
-```
+1. `conda activate carpentries`
+2. `jupyter notebook`
 
-To install the packages we'll be using in the workshop, type:
+::::::::::::::::::::::::::::::::::::::::::::::::::
 
-```bash
-conda install -y numpy pandas matplotlib jupyter
-conda install -c conda-forge plotnine
-```
+:::::::::::::::::::::::::::::::::::::::::: spoiler
 
-:::::::::::::::::::::::::
+##### Linux
 
-After installing either Anaconda or Miniconda and the workshop packages,
-launch a Jupyter notebook by typing this command from the terminal:
+After following the instructions above, search for the application 'Miniforge Prompt' and open it. 
+Type the following commands, pressing <kbd>Enter</kbd> after each one:
 
-```bash
-jupyter notebook
-```
+1. `conda activate carpentries`
+2. `jupyter notebook`
 
-The notebook should open automatically in your browser. If it does not or you
-wish to use a different browser, open this link: [http://localhost:8888](https://localhost:8888).
+::::::::::::::::::::::::::::::::::::::::::::::::::
+
+The notebook should open automatically in your browser. 
+If it does not or you wish to use a different browser, open this link: [http://localhost:8888](https://localhost:8888).
 
 For a brief introduction to Jupyter Notebooks, please consult our
 [Introduction to Jupyter Notebooks](https://datacarpentry.org/python-ecology-lesson/jupyter_notebooks/) page.

--- a/files/setup-python.md
+++ b/files/setup-python.md
@@ -20,8 +20,10 @@ Please refer to the [Python section of the workshop website for installation ins
 After following the instructions above, search for the application 'Miniforge Prompt' and open it. 
 Type the following commands, pressing <kbd>Enter</kbd> after each one:
 
-1. `conda activate carpentries`
-2. `jupyter notebook`
+```bash
+conda activate carpentries
+jupyter notebook
+```
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
@@ -32,9 +34,10 @@ Type the following commands, pressing <kbd>Enter</kbd> after each one:
 After following the instructions above, open the Terminal application (inside Applications/Utilities). 
 Type the following commands, pressing <kbd>Enter</kbd> after each one:
 
-1. `conda activate carpentries`
-2. `jupyter notebook`
-
+```bash
+conda activate carpentries
+jupyter notebook
+```
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
 :::::::::::::::::::::::::::::::::::::::::: spoiler
@@ -44,8 +47,10 @@ Type the following commands, pressing <kbd>Enter</kbd> after each one:
 After following the instructions above, search for the application 'Miniforge Prompt' and open it. 
 Type the following commands, pressing <kbd>Enter</kbd> after each one:
 
-1. `conda activate carpentries`
-2. `jupyter notebook`
+```bash
+conda activate carpentries
+jupyter notebook
+```
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/setup-python-workshop.Rmd
+++ b/setup-python-workshop.Rmd
@@ -2,9 +2,6 @@
 title: Setup for Python workshops
 ---
 
-```{r include-setup-python, child="files/setup-python.md"}
-```
-
 ## Software
 
 | Software            | Install                         | Manual | Available for         | Description                                               | 
@@ -13,6 +10,9 @@ title: Setup for Python workshops
 | OpenRefine          | [Link](http://openrefine.org/download.html)                                | [Link](http://openrefine.org/documentation.html)       | Linux, MacOS, Windows | Program for reproducibly cleaning data.                   | 
 | Python              | See install instructions below. |        | Linux, MacOS, Windows | Programming language for data analysis and visualisation. | 
 | SQLite Browser      | [Link](http://sqlitebrowser.org/dl/)                                | [Link](https://github.com/sqlitebrowser/sqlitebrowser/wiki)       | Linux, MacOS, Windows | Tool for creating, designing, and editing database files. | 
+
+```{r include-setup-python, child="files/setup-python.md"}
+```
 
 ```{r include-setup-sql, child="files/setup-sql.md"}
 ```


### PR DESCRIPTION
This updates the setup instructions for Python workshops. [A recent blog post provides more context for this change](https://carpentries.org/blog/2025/03/lesson-setup-instructions-task-force-recommendations/).

Two major changes have been made:

1. the page now points to [the central Python setup instructions](https://carpentries.github.io/workshop-template/install_instructions/#python) that we maintain as part of the workshop website template repository.
2. The instructions now reflect that we recommend Miniforge instead of Anaconda Python. This means that learners need to activate a `carpentries` environment before they can launch a Jupyter notebook server.